### PR TITLE
Fix down arrow banner link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                         <li><a href="https://www.facebook.com/illinoisfounders" class="button big">Join Us</a></li>
                     </ul>
                 </div>
-                <a href="bit.ly/start-a-startup-uiuc" class="more">Start a Startup</a>
+                <a href="https://bit.ly/start-a-startup-uiuc" class="more">Start a Startup</a>
             </section>
             <!-- Wrapper -->
             <div id="wrapper">


### PR DESCRIPTION
Anchor tag that represented the down arrow tab at the foot of the header had an href attribute that pointed to a not found local domain (http://founders.illinois.edu/bit.ly/start-a-startup-uiuc) rather than **https://** bit.ly/start-a-startup-uiuc.